### PR TITLE
Summarize create-polkadot-dapp bootstrap

### DIFF
--- a/frontend/wagmi.config.ts
+++ b/frontend/wagmi.config.ts
@@ -5,7 +5,7 @@ import path from "path";
 
 let dirEntries: fs.Dirent[] = [];
 
-const deploymentsDir = path.join("..", "contracts", "ignition", "deployments");
+const deploymentsDir = path.join("..", "T-REX", "deployment");
 
 try {
   dirEntries.push(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Wagmi config to locate T-REX contract deployment addresses.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change points the dApp's Wagmi configuration to the directory containing the deployed T-REX contract addresses (`T-REX/deployment/420420420.json`). It's the initial step in integrating the T-REX contracts, with further modifications required to correctly locate contract ABIs.

---
<a href="https://cursor.com/background-agent?bcId=bc-e52f723b-d943-42c1-9a59-ec47cb3ae11e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e52f723b-d943-42c1-9a59-ec47cb3ae11e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

